### PR TITLE
Added timeout for getStdin and trim trailing new lines

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 const meow = require('meow');
-const getStdin = require('get-stdin');
+const getStdin = require('stdin2');
 const clipboardy = require('clipboardy');
 
 meow(`
@@ -15,6 +15,13 @@ if (process.stdin.isTTY || process.env.STDIN === '0') {
 	process.stdout.write(clipboardy.readSync());
 } else {
 	(async () => {
-		clipboardy.writeSync(await getStdin());
+        try {
+            const text = await getStdin({ timeout: 30 });
+            clipboardy.writeSync(text.replace(/(\r\n|\n|\r)$/gm, " "));
+        }
+        catch (e) {
+            process.stdout.write(clipboardy.readSync());
+            process.exit(0);
+        }
 	})();
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	],
 	"dependencies": {
 		"clipboardy": "^2.0.0",
-		"get-stdin": "^7.0.0",
+		"stdin2": "^1.0.0",
 		"meow": "^5.0.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
* Added timeout to getStdin:
    In some CLI the `if (process.stdin.isTTY || process.env.STDIN === '0')` check isn't enough. Some CLI like git bash on windows just hang on the getStdin call. Solved this by using a getStdin function with support for timeout.

* Removed trailing new lines:
    Trying to paste something into the cli and having it paste a new line which runs an uncompleted command is not great. Keep new lines in the middle to support copying multi line text, but remove trailing new lines to prevent unnecessary commands to run.